### PR TITLE
feat: add cookieConsent

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -4,6 +4,8 @@ import Header from './Header';
 import Footer from './Footer';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
+import CookieConsent from "react-cookie-consent";
+
 
 export default function Layout({
     children,
@@ -96,6 +98,16 @@ export default function Layout({
                 <section className='content'>{children}</section>
             </main>
             <Footer />
+            <CookieConsent
+                location="bottom"
+                buttonText="Of course!"
+                cookieName="cookiepolicy"
+                style={{ background: "#2B373B" }}
+                buttonStyle={{ color: "#4e503b", fontSize: "13px" }}
+                expires={150}
+            >
+                This website uses cookies to enhance the user experience.
+            </CookieConsent>
             <Script
                 src="https://www.googletagmanager.com/gtag/js?id=UA-175469686-4"
                 strategy="afterInteractive"

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -5,7 +5,7 @@ import Footer from './Footer';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import CookieConsent from "react-cookie-consent";
-
+import Link from 'next/link';
 
 export default function Layout({
     children,
@@ -106,7 +106,7 @@ export default function Layout({
                 buttonStyle={{ color: "#4e503b", fontSize: "13px" }}
                 expires={150}
             >
-                This website uses cookies to enhance the user experience.
+                This website uses cookies to enhance the user experience. <Link href='/cookie'><u>Cookie policy</u></Link>
             </CookieConsent>
             <Script
                 src="https://www.googletagmanager.com/gtag/js?id=UA-175469686-4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1527,6 +1527,11 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
+    "js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
+    },
     "js-sdsl": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
@@ -1897,6 +1902,14 @@
         "eve": "~0.5.1",
         "prop-types": "^15.7.2",
         "snapsvg-cjs": "0.0.6"
+      }
+    },
+    "react-cookie-consent": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/react-cookie-consent/-/react-cookie-consent-8.0.1.tgz",
+      "integrity": "sha512-4A2jzPQDFfBhtxIz4hYX+vJ0QnOknGdOXpEoetXzgwUrMtxVJVow8YgBsGerNt5rJI7WhKkHwr8LmxekxgVejg==",
+      "requires": {
+        "js-cookie": "^2.2.1"
       }
     },
     "react-dom": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "next-intl": "^2.9.1",
     "react": "18.2.0",
     "react-burger-menu": "^3.0.8",
+    "react-cookie-consent": "^8.0.1",
     "react-dom": "18.2.0",
     "react-i18next": "^12.0.0",
     "typescript": "4.8.4"

--- a/pages/cookie.tsx
+++ b/pages/cookie.tsx
@@ -1,0 +1,64 @@
+import { useTranslations } from 'next-intl';
+import TextSection from '../components/TextSection';
+
+export async function getStaticProps({ locale }: { locale: any }) {
+  return {
+    props: {
+      metas: {
+        title: 'Cookie, Open Source Day 2023 - Florence',
+        description:
+          'Open Source Day 2023 coming soon on March 2023. Stay tuned on our social'
+      },
+      messages: (await import(`../public/locales/${locale}.json`)).default
+    }
+  };
+}
+
+export default function DEI() {
+  const t = useTranslations('DEI');
+
+  return (
+    <>
+      <div className='container'>
+        <TextSection
+          heading1={'Cookie Policy'}
+          heading2={''}
+          text={
+            <>
+            <p>Please read this cookie policy (&quot;cookie policy&quot;, &quot;policy&quot;) carefully before using osday.dev website (&quot;website&quot;, &quot;service&quot;) operated by schrodinger hat (&quot;us&quot;, &quot;we&quot;, &quot;our&quot;).</p>
+            <h4>What are cookies?</h4>
+            <p>
+              Cookies are simple text files that are stored on your computer or mobile device by a website&apos;s server. Each cookie is unique to your web browser.
+              It will contain some anonymous information such as a unique identifier, website&apos;s domain name, and some digits and numbers.
+            </p>
+            <h4>What types of cookies do we use?</h4>
+            <h5>Necessary cookies</h5>
+            <p>
+              Necessary cookies allow us to offer you the best possible experience when accessing and navigating through our website and using its features.
+              For example, these cookies let us recognize that you have created an account and have logged into that account.
+            </p>
+            <h5>Functionality cookies</h5>
+            <p>
+              Functionality cookies let us operate the site in accordance with the choices you make.
+              For example, we will recognize your username and remember how you customized the site during future visits.
+            </p>
+            <h5>Analytical cookies</h5>
+            <p>
+              These cookies enable us and third-party services to collect aggregated data for statistical purposes on how our visitors use the website.
+              These cookies do not contain personal information such as names and email addresses and are used to help us improve your user experience of the website.
+            </p>
+            <h4>How to delete cookies?</h4>
+            <p>
+              If you want to restrict or block the cookies that are set by our website, you can do so through your browser setting.
+              Alternatively, you can visit www.internetcookies.com, which contains comprehensive information on how to do this on a wide variety of browsers and devices.
+              You will find general information about cookies and details on how to delete cookies from your device.
+            </p>
+            <h4>Contacting us</h4>
+            <p>If you have any questions about this policy or our use of cookies, please contact us osday@schrodinger-hat.it.</p>
+          </>
+          }
+          />
+      </div>
+    </>
+  );
+}

--- a/pages/cookie.tsx
+++ b/pages/cookie.tsx
@@ -34,13 +34,8 @@ export default function DEI() {
             <h4>What types of cookies do we use?</h4>
             <h5>Necessary cookies</h5>
             <p>
-              Necessary cookies allow us to offer you the best possible experience when accessing and navigating through our website and using its features.
-              For example, these cookies let us recognize that you have created an account and have logged into that account.
-            </p>
-            <h5>Functionality cookies</h5>
-            <p>
-              Functionality cookies let us operate the site in accordance with the choices you make.
-              For example, we will recognize your username and remember how you customized the site during future visits.
+              Necessary cookies allow us to offer you the best possible experience when accessing and navigating through our website.
+              For example, these cookies let us recognize that you have visualize our static notification.
             </p>
             <h5>Analytical cookies</h5>
             <p>


### PR DESCRIPTION
Closes #59 

- add react-cookie-consent package
- add generic cookie policy, monolanguage
- add link in cookie policy banner


![image](https://user-images.githubusercontent.com/6616203/203584272-adb0a67b-85b6-4332-9ced-3ee578aec80a.png)
