### PR TITLE
Fix header/scroll flickering and properly apply position: sticky

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -23,11 +23,10 @@ export default function Header() {
     'es': '🇪🇸'
   };
 
-
   useEffect(() => {
     setLanguageCode(document.documentElement.lang);
 
-    const handleScroll = () => setSticky(window.pageYOffset > 60);
+    const handleScroll = () => setSticky(window.scrollY > 60 || isSticky && window.scrollY > 0);
     window.addEventListener('scroll', handleScroll);
 
     return () => {

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -102,8 +102,8 @@ export default function Layout({
                 <div className='image-background'>
                     <Header />
                     <section className='content'>{children}</section>
+                    <SponsorTable isVisible={areSponsorVisible()}/>
                 </div>
-                <SponsorTable isVisible={areSponsorVisible()}/>
             </main>
             <Footer />
             <CookieConsent

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -8,7 +8,7 @@ body {
   font-weight: normal;
   padding: 0;
   margin: 0;
-  overflow-x: hidden;
+  overflow-x: clip;
 }
 
 .bg-primary {
@@ -86,6 +86,9 @@ button {
 }
 
 .nav {
+  position: sticky;
+  z-index: 10;
+  top: 0;
   left: 1em;
   display: flex;
   width: 98%;
@@ -759,10 +762,6 @@ div.image .img {
 
 
 .sticky {
-  position: fixed;
-  left: 0;
-  top: 0;
-  z-index: 10;
   width: 100%;
   background: #171717;
   transition: all 250ms cubic-bezier(0.4, 0, 1, 1);
@@ -838,12 +837,6 @@ div.image .img {
 }
 
 @media screen and (max-width: 768px) {
-  .sticky {
-    position: relative;
-    width: auto;
-    transition: none;
-  }
-  
   .cta-container {
     display: flex;
     flex-flow: column;
@@ -1109,9 +1102,7 @@ div.image .img {
   }
 
   .sticky {
-    position: fixed;
     left: 0;
-    top: 0;
     z-index: 10;
     width: 100%;
     background: #171717;


### PR DESCRIPTION
This PR fixes #86 

That flickering header was a bit annoying, I slightly refactored the logic a little bit by extending the `isSticky` condition on `Header.tsx` and with some little changes on `global.scss` to properly apply `position: sticky;`

---

Since I removed `position: fixed` I also had to make sure `SponsorTable` is inside the right parent or the header disappears when scrolling above that section.
I don't know why it was outside, in case it has to be moved back let me know :)