### PR TITLE
Call for volunteers typo

### DIFF
--- a/pages/cfv.tsx
+++ b/pages/cfv.tsx
@@ -22,7 +22,7 @@ export default function CFV() {
       <div className="container">
         <Hero
           title="Open Source Day 2023"
-          subtitle="Call for volounteers"
+          subtitle="Call for volunteers"
           description={t('description')}
           originals={false}
           mainCta={{


### PR DESCRIPTION
Description:

There is a typo on cfv page "Call for volunteers" doesnt have the o:
![215740691-598d2634-69c2-4ba8-9611-720251643186](https://user-images.githubusercontent.com/55488549/215808165-8a99bcb4-0ce7-4ef8-9921-ddf730bf3040.png)

#175 
@tarunsamanta2k20 