### PR TITLE
feat(297): add emailOctupus subscribe form

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -129,6 +129,11 @@ export default function Layout({
                 gtag('send', 'pageview');
                 `}
             </Script>
+            <Script
+                async
+                src="https://eocampaign1.com/form/e9fb84c2-ebfc-11ed-8424-fbce0ce9d7bc.js"
+                data-form="e9fb84c2-ebfc-11ed-8424-fbce0ce9d7bc"
+            />
         </>
     );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1494,6 +1494,10 @@ div.image .img {
   width: 60%;
 }
 
+.slide-in-container-inner .mastfoot {
+  display: none !important;
+}
+
 @media screen and (max-width: 1500px) {
   .talks_container {
     grid-template-columns: 1fr;


### PR DESCRIPTION
Closes #297 

All the settings are manageable from EmailOctupus dashboard.
People signing up from this point of access will have a tag "osday-website"

![image](https://github.com/Schrodinger-Hat/osday/assets/6616203/22c3d76b-2ea3-43f7-b9fb-47b9f379ea62)