### PR TITLE
fix: newsletter error feedback

### DIFF
--- a/pages/newsletter.tsx
+++ b/pages/newsletter.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useRef, useState } from 'react';
 import Image from 'next/image';
 import Hero from '../components/Hero';
 import { useTranslations } from 'next-intl';
@@ -24,6 +24,7 @@ export default function Newsletter() {
       email: '',
       emailError: false,
   });
+  const emailInputRef = useRef<HTMLInputElement>(null);
 
   const newsletterImage = newsletterState.subscribed ?
     '/newsletter/lore.jpg'
@@ -34,6 +35,7 @@ export default function Newsletter() {
     return;
     
     if(!newsletterState.email.match(/^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/i)) {
+      emailInputRef?.current?.focus();
       setNewsletterState(() => {
         return {
           ...newsletterState,
@@ -78,6 +80,7 @@ export default function Newsletter() {
             />
             <div className='title-box'>
               {!newsletterState.subscribed ? <input
+                ref={emailInputRef}
                 type='email'
                 className='input-newsletter mb-2'
                 style={{

--- a/pages/newsletter.tsx
+++ b/pages/newsletter.tsx
@@ -45,6 +45,11 @@ export default function Newsletter() {
       return;
     }
 
+    setNewsletterState((prev) => ({
+      ...prev,
+      waiting: true,
+    }));
+
     const res = await fetch('/api/email-octupus', {
       method: 'POST',
       headers: {
@@ -56,15 +61,16 @@ export default function Newsletter() {
     if (res.status === 200) {
         const data = await res.json();
         if (data.id) {
-          setNewsletterState(() => {
-            return {
-              ...newsletterState,
-              subscribed: true,
-              waiting: false,
-            }
-          })
+          setNewsletterState((prev) => ({
+            ...prev,
+            subscribed: true,
+          }));
         }
     }
+    setNewsletterState((prev) => ({
+      ...prev,
+      waiting: false,
+    }));
 }
 
   return (

--- a/pages/newsletter.tsx
+++ b/pages/newsletter.tsx
@@ -66,6 +66,16 @@ export default function Newsletter() {
             subscribed: true,
           }));
         }
+        if (data.error?.code) {
+          switch (data.error.code) {
+            case "MEMBER_EXISTS_WITH_EMAIL_ADDRESS":
+              alert('You are already subscribed to our newsletter');
+              break;
+            default:
+              alert('An error occurred, please try again later');
+              break;
+          }
+        }
     }
     setNewsletterState((prev) => ({
       ...prev,


### PR DESCRIPTION
Hey! I tried to signup to the newsletter but... nothing happened!
Turns out I was already registered but I didn't get any feedback from the page when I was trying to signup again.

I fixed a couple things there:
- If the email is invalid we set the border red, but this is visible only if the input is focused and it loses focus when you click the button -> now it refocuses the input if that's the case
- The waiting state (changing the button text and preventing further clicks) wasn't set
- I added an ugly alert to inform if the user is already registered or if a generic error happened.

Let me know what you think! I did 3 separate commits so if we want to keep some and discard others it's easy :)