### PR TITLE
Better schedule layout on desktop

### DIFF
--- a/src/app/(website)/(main)/schedule/page.tsx
+++ b/src/app/(website)/(main)/schedule/page.tsx
@@ -8,6 +8,7 @@ import type { TimelineItem } from "~/components/molecules/talks-table";
 import { getAuthorFullName } from "~/lib/sanity-cms";
 import { getCacheTag, sanityFetch } from "~/lib/sanity-fetch";
 import { constructMetadata } from "~/lib/utils/metadata";
+import { cn } from "~/lib/utils";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -31,8 +32,8 @@ function TimelineCard({ item }: { item: TimelineItem }) {
   const type = item.type as keyof typeof TYPE_BACKGROUNDS;
   const backgroundGradient = TYPE_BACKGROUNDS[type] ?? TYPE_BACKGROUNDS.talk;
 
-  // Only make talks and keynotes clickable
-  const isClickable = ["talk", "keynote"].includes(type);
+  // Only make talks clickable
+  const isClickable = type === "talk";
 
   const content = (
     <>
@@ -47,12 +48,17 @@ function TimelineCard({ item }: { item: TimelineItem }) {
         />
       ) : (
         <div
-          className={`absolute inset-0 bg-gradient-to-br ${backgroundGradient} transition-transform duration-300 group-hover:scale-105`}
+          className={`absolute inset-0 bg-gradient-to-br ${backgroundGradient} opacity-50 transition-transform duration-300 group-hover:scale-105`}
         />
       )}
 
       {/* Content */}
-      <div className="absolute inset-0 m-2 flex flex-col justify-between rounded-sm bg-black/80 p-4">
+      <div
+        className={cn(
+          "absolute inset-0 m-2 flex flex-col justify-between rounded-sm bg-black/80 p-4",
+          !isClickable && "border-2 border-dashed border-white",
+        )}
+      >
         <div className="space-y-3">
           <time className="block font-title text-2xl tracking-wider text-white/90">
             {new Intl.DateTimeFormat("it-IT", {
@@ -83,9 +89,10 @@ function TimelineCard({ item }: { item: TimelineItem }) {
     </>
   );
 
-  const className = `group relative aspect-[4/3] overflow-hidden rounded-md shadow-md ${
-    isClickable ? "cursor-pointer transition hover:scale-[1.02]" : ""
-  }`;
+  const className = cn(
+    "group relative aspect-[4/3] overflow-hidden rounded-md shadow-md",
+    isClickable && "cursor-pointer transition hover:scale-[1.02]",
+  );
 
   if (isClickable) {
     return (
@@ -96,6 +103,16 @@ function TimelineCard({ item }: { item: TimelineItem }) {
   }
 
   return <div className={className}>{content}</div>;
+}
+
+function HourGroup({ items }: { items: TimelineItem[] }) {
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {items.map((item) => (
+        <TimelineCard key={item._id} item={item} />
+      ))}
+    </div>
+  );
 }
 
 export default async function SchedulePage() {
@@ -122,6 +139,26 @@ export default async function SchedulePage() {
     },
   );
 
+  // Group items by hour
+  const groupedTimeline = timeline.reduce<Record<string, TimelineItem[]>>(
+    (acc, item) => {
+      const hour = new Intl.DateTimeFormat("it-IT", {
+        hour: "2-digit",
+        timeZone: "Europe/Rome",
+      }).format(new Date(item.startDateTime));
+
+      if (!acc[hour]) {
+        acc[hour] = [];
+      }
+      acc[hour].push(item);
+      return acc;
+    },
+    {},
+  );
+
+  // Sort hours
+  const sortedHours = Object.keys(groupedTimeline).sort();
+
   return (
     <>
       <SectionContainer withBackground backgroundType="hero">
@@ -132,9 +169,9 @@ export default async function SchedulePage() {
       </SectionContainer>
 
       <SectionContainer>
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {timeline.map((item) => (
-            <TimelineCard key={item._id} item={item} />
+        <div className="space-y-8">
+          {sortedHours.map((hour) => (
+            <HourGroup key={hour} items={groupedTimeline[hour] ?? []} />
           ))}
         </div>
       </SectionContainer>

--- a/src/app/(website)/(main)/schedule/page.tsx
+++ b/src/app/(website)/(main)/schedule/page.tsx
@@ -57,30 +57,37 @@ function TimelineCard({ item }: { item: TimelineItem }) {
       <div
         className={cn(
           "absolute inset-0 m-2 flex flex-col justify-between rounded-sm bg-black/80 p-4",
-          !isClickable && "border-2 border-dashed border-white",
+          !isClickable && "border-2 border-dashed border-white bg-black/40",
         )}
       >
         <div className="space-y-3">
-          <time className="block font-title text-2xl tracking-wider text-white/90">
+          <Heading
+            level={3}
+            className="mb-0 text-white drop-shadow-[2px_2px_0px_rgba(0,0,0,0.50)] md:mb-0"
+          >
             {asFormattedTime(item.startDateTime)}
-          </time>
+          </Heading>
 
-          <div className="space-y-2">
-            <h3 className="text-xl font-semibold leading-tight text-white">
-              {item.title}
-            </h3>
-          </div>
+          <Typography variant="h4" className="leading-tight text-white">
+            {item.title}
+          </Typography>
         </div>
 
         {item.author && (
-          <div className="rounded-full py-1.5 text-sm font-medium text-white/90 backdrop-blur-sm">
+          <Typography
+            variant="small"
+            className="rounded-md bg-white/20 p-2 font-semibold text-white/90"
+          >
             {getAuthorFullName(item.author)}
-          </div>
+          </Typography>
         )}
         {!item.author && (
-          <span className="inline-block rounded bg-white/20 px-2.5 py-1 text-sm font-medium text-white backdrop-blur-sm">
+          <Typography
+            variant="small"
+            className="rounded-md bg-white/20 p-2 font-semibold text-white/90"
+          >
             {item.type.charAt(0).toUpperCase() + item.type.slice(1)}
-          </span>
+          </Typography>
         )}
       </div>
     </>
@@ -104,7 +111,7 @@ function TimelineCard({ item }: { item: TimelineItem }) {
 
 function HourGroup({ items }: { items: TimelineItem[] }) {
   return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+    <div className="grid grid-cols-1 gap-4 border-b-2 border-dotted border-primary/30 pb-4 sm:grid-cols-2 lg:grid-cols-3">
       {items.map((item) => (
         <TimelineCard key={item._id} item={item} />
       ))}
@@ -139,10 +146,7 @@ export default async function SchedulePage() {
   // Group items by hour
   const groupedTimeline = timeline.reduce<Record<string, TimelineItem[]>>(
     (acc, item) => {
-      const hour = new Intl.DateTimeFormat("it-IT", {
-        hour: "2-digit",
-        timeZone: "Europe/Rome",
-      }).format(new Date(item.startDateTime));
+      const hour = asFormattedTime(item.startDateTime, true);
 
       if (!acc[hour]) {
         acc[hour] = [];
@@ -166,7 +170,7 @@ export default async function SchedulePage() {
       </SectionContainer>
 
       <SectionContainer>
-        <div className="space-y-8">
+        <div className="space-y-4">
           {sortedHours.map((hour) => (
             <HourGroup key={hour} items={groupedTimeline[hour] ?? []} />
           ))}

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -3,7 +3,13 @@ const formatter = new Intl.DateTimeFormat("it-IT", {
   minute: "2-digit",
   timeZone: "Europe/Rome",
 });
+const hourFormatter = new Intl.DateTimeFormat("it-IT", {
+  hour: "2-digit",
+  timeZone: "Europe/Rome",
+});
 
-export function asFormattedTime(time: string) {
-  return formatter.format(new Date(time));
+export function asFormattedTime(time: string, withoutMinutes = false) {
+  return withoutMinutes
+    ? hourFormatter.format(new Date(time))
+    : formatter.format(new Date(time));
 }


### PR DESCRIPTION
Improve legibility by grouping items in hours
Replace custom with standard typography
Items that are not a task are not clickable
Drop-shadow on time to make it more readable in low-contrast scenarios

<img width="1026" alt="Screenshot 2025-03-07 at 10 06 25" src="https://github.com/user-attachments/assets/af1b1ad9-f9f7-476c-b3ec-7ec086f03764" />
