### PR TITLE
fix: Repair 2021 broken link

### DIFF
--- a/src/app/(website)/(secondary)/previous-events/page.tsx
+++ b/src/app/(website)/(secondary)/previous-events/page.tsx
@@ -43,7 +43,7 @@ export default function PreviousEventsPage() {
             </div>
             <Heading level={3}>OSDay 23</Heading>
           </Link>
-          <Link href="https://osday.dev/edition2021">
+          <Link href="https://2024.osday.dev/edition2021">
             <div className="aspect-video overflow-hidden rounded-md shadow-md">
               <Image src={osday21} alt="Event 3" />
             </div>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the code of conduct before creating a pull request
 👉 https://schroedinger-hat.org/code-of-conduct
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

Resolves #629

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This PR is the last step to close the #629 issue. All other environments that targeted previous OSDay events have been deployed into Vercel (See: [2024](https://2024.osday.dev) and [2023](https://2023.osday.dev).

Since 2021 never had an OSDay environment by it's own, we just needed to fix the URL that was currently deployed in the prod environment.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
