### PR TITLE
feat: add explicit second day to conference details

### DIFF
--- a/src/app/(website)/page.tsx
+++ b/src/app/(website)/page.tsx
@@ -93,9 +93,14 @@ export default async function HomePage() {
           unmissable gathering of developers, tech enthusiasts, and
           forward-thinking innovators.
           <br />
-          On <b>April 24st</b>, join us at the vibrant{" "}
+          <br />
+          On <b>April 24th</b>, join us at the vibrant{" "}
           <i>The Social Hub Firenze Belfiore</i> in Florence for a full day of
           talks that dive deep into today's most exciting open source trends.
+          <br />
+          <br />
+          On <b>April 25th</b>, we will host a day of hands-on workshops to
+          deepen your skills and collaborate with fellow developers.
           <br />
           Connect with like-minded peers, learn from top industry experts, and
           discover how open collaboration is shaping the future of technology.

--- a/src/app/_components/hero.tsx
+++ b/src/app/_components/hero.tsx
@@ -16,7 +16,7 @@ import defaultEventImage from "~/assets/images/venue/auditorium.jpg";
 
 const stats = [
   { label: "Speakers", value: "16" },
-  { label: "When", value: "24th of April" },
+  { label: "When", value: "24th & 25th of April" },
   { label: "Venue", value: "The Social Hub Belfiore" },
   { label: "Location", value: "Florence, Italy" },
 ];

--- a/src/components/molecules/talks-table.tsx
+++ b/src/components/molecules/talks-table.tsx
@@ -154,16 +154,16 @@ export function TalksTable({ talks }: TalksTableProps) {
     <div>
       {/* Day tabs */}
       {isMultiDay && (
-        <div className="mb-8 flex flex-wrap gap-2">
+        <div className="mb-8 flex flex-wrap gap-3">
           {dayKeys.map((dk, i) => (
             <button
               key={dk}
               onClick={() => setSelectedDay(dk)}
               className={cn(
-                "rounded-full border px-4 py-1.5 text-sm font-medium transition-colors",
+                "rounded-full border-2 px-6 py-2 text-base font-semibold transition-colors",
                 selectedDay === dk
                   ? "border-primary bg-primary text-primary-foreground"
-                  : "border-primary/30 hover:border-primary/60",
+                  : "border-primary bg-primary/10 text-primary hover:bg-primary/20",
               )}
             >
               {getDayLabel(dk, i)}


### PR DESCRIPTION
### Goal

Make it clear that the conference spans two days (April 24th talks + April 25th workshops).

### Summary

- Update hero stat from "24th of April" to "24th & 25th of April"
- Add April 25th workshops sentence to homepage description with paragraph spacing
- Fix "24st" typo to "24th"
- Improve day tab button visibility in schedule (bigger, better contrast for inactive state)

### Technical Changes

- `src/app/_components/hero.tsx` - updated `When` stat value
- `src/app/(website)/page.tsx` - added workshops sentence, fixed typo, added `<br />` spacing
- `src/components/molecules/talks-table.tsx` - improved day tab button styling (larger padding, solid border, tinted background for inactive state)

Checklist:
- [x] manually checked my feature / not applicable
- [ ] wrote tests / not applicable
- [x] attached screenshots / not applicable

### Media

<img width="582" height="136" alt="image" src="https://github.com/user-attachments/assets/d78fda3f-8ca6-4e66-beb7-e4b6823e644a" />


<img width="1310" height="1096" alt="image" src="https://github.com/user-attachments/assets/e6204cbd-1a25-48e9-90a6-f82838eaca7c" />

<img width="1310" height="418" alt="image" src="https://github.com/user-attachments/assets/759e880d-95d6-430c-8afe-ca2413ede82f" />
