### PR TITLE
Fix for Comparison between inconvertible types

### DIFF
--- a/src/app/api/algolia/reindex/standalone-reindex.ts
+++ b/src/app/api/algolia/reindex/standalone-reindex.ts
@@ -147,12 +147,7 @@ function extractTextFromSanityObject(obj: unknown): string {
   // Fallback for primitives
   try {
     // For primitive values only
-    if (
-      typeof obj === "number" ||
-      typeof obj === "boolean" ||
-      obj === null ||
-      obj === undefined
-    ) {
+    if (typeof obj === "number" || typeof obj === "boolean") {
       return String(obj);
     }
     return "";


### PR DESCRIPTION
To fix this without changing behavior, remove unreachable `null`/`undefined` comparisons in the fallback primitive block, since those values already return at line 112.

Best single fix in `src/app/api/algolia/reindex/standalone-reindex.ts`:
- In `extractTextFromSanityObject`, update the condition in the fallback section (around lines 150–155) to only check remaining primitive cases that can still occur there (`number` and `boolean`).
- Keep `return String(obj);` as-is for those primitive types.
- No imports, new methods, or dependency changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._