### PR TITLE
Fix for Comparison between inconvertible types

### DIFF
--- a/src/components/search/search-dialog.tsx
+++ b/src/components/search/search-dialog.tsx
@@ -49,7 +49,7 @@ function extractTextFromSanityObject(obj: unknown): string {
   }
 
   // For other objects, try to extract from their values
-  if (typeof obj === "object" && obj !== null) {
+  if (typeof obj === "object") {
     try {
       const keys = Object.keys(objTyped);
       return keys.length > 0


### PR DESCRIPTION
To fix this, remove the redundant `obj !== null` comparison in the object-processing branch, since null/undefined/falsy values already return at line 34.

Best minimal fix (no functionality change):
- In `src/components/search/search-dialog.tsx`, inside `extractTextFromSanityObject`, update the condition at line 52 from:
  - `if (typeof obj === "object" && obj !== null) {`
  to:
  - `if (typeof obj === "object") {`

No new methods/imports/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._