### PR TITLE
Fix for Comparison between inconvertible types

### DIFF
--- a/src/app/api/algolia/reindex/standalone-reindex.ts
+++ b/src/app/api/algolia/reindex/standalone-reindex.ts
@@ -127,7 +127,7 @@ function extractTextFromSanityObject(obj: unknown): string {
   }
 
   // For other objects, try to extract from their values
-  if (typeof obj === "object" && obj !== null) {
+  if (typeof obj === "object") {
     try {
       const keys = Object.keys(objTyped);
       if (keys.length === 0) return "";


### PR DESCRIPTION
The best fix is to remove the redundant null comparison at line 130 and rely on the earlier null/undefined guard (`if (!obj) return ""`).  
Concretely, in `src/app/api/algolia/reindex/standalone-reindex.ts`, replace:

- `if (typeof obj === "object" && obj !== null) {`

with:

- `if (typeof obj === "object") {`

This preserves existing functionality (null is still handled at line 112), keeps object-handling logic intact, and resolves the CodeQL complaint about an always-true null comparison in this branch. No new imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._