### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/app/(website)/(main)/tickets/page.tsx
+++ b/src/app/(website)/(main)/tickets/page.tsx
@@ -36,7 +36,7 @@ function resolveCouponParam(
 }
 
 export default async function TicketsPage({ searchParams }: TicketsPageProps) {
-  const { coupon: couponParam } = await searchParams;
+  await searchParams;
 
   const speakers: Author[] = await sanityFetch(
     `*[_type == "event" && slug.current == "open-source-day-2026"][0].authors[]->{


### PR DESCRIPTION
To fix this without changing behavior, remove the unused `couponParam` extraction from `searchParams`.  
In `src/app/(website)/(main)/tickets/page.tsx`, update the `TicketsPage` function to avoid creating an unused variable.

Best single change:
- Replace `const { coupon: couponParam } = await searchParams;` with `await searchParams;` so the awaited behavior is preserved (in case it has side effects/timing expectations), while eliminating the unused variable warning.

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._