### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -2,7 +2,6 @@
 
 import * as React from "react";
 import Link from "next/link";
-import dynamic from "next/dynamic";
 import { useScrollDirection } from "~/hooks/use-scroll-direction";
 import { usePathname } from "next/navigation";
 import { MobileNav } from "./mobile-nav";


### PR DESCRIPTION
The best fix is to remove the unused `dynamic` import from `src/components/layout/header.tsx` without changing any runtime behavior. This is a no-risk cleanup: no logic depends on `dynamic`, and removing it preserves current functionality while satisfying CodeQL and keeping imports accurate.

Change required:
- In `src/components/layout/header.tsx`, delete the line:
  - `import dynamic from "next/dynamic";`

No additional methods, definitions, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._