### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/app/(website)/(main)/tickets/page.tsx
+++ b/src/app/(website)/(main)/tickets/page.tsx
@@ -25,16 +25,6 @@ interface TicketsPageProps {
   searchParams: Promise<{ coupon?: string | string[] }>;
 }
 
-function resolveCouponParam(
-  coupon: string | string[] | undefined,
-): string | undefined {
-  if (coupon === undefined) return undefined;
-  const raw = Array.isArray(coupon) ? coupon[0] : coupon;
-  const trimmed = raw?.trim() ?? "";
-  if (trimmed.length === 0) return undefined;
-  return trimmed;
-}
-
 export default async function TicketsPage({ searchParams }: TicketsPageProps) {
   const { coupon: couponParam } = await searchParams;
 


### PR DESCRIPTION
To fix this, remove the unused `resolveCouponParam` function from `src/app/(website)/(main)/tickets/page.tsx`.

Best approach (no functionality change):
- Delete the entire function block at lines 28–36.
- Keep all imports and runtime logic unchanged.
- This eliminates the CodeQL warning while preserving current behavior, since the function is not called.

No new imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._